### PR TITLE
Update modal text color to use theme secondary color

### DIFF
--- a/MacroTracker/src/components/AiPromotionModal.tsx
+++ b/MacroTracker/src/components/AiPromotionModal.tsx
@@ -43,7 +43,7 @@ const AiPromotionModal: React.FC<AiPromotionModalProps> = ({ isVisible, onClose,
             {t('aiPromo.title')}
           </Text>
           
-          <Text style={[styles.message, { color: theme.colors.grey2 }]}>
+          <Text style={[styles.message, { color: theme.colors.secondary }]}>
             {t('aiPromo.message')}
           </Text>
 

--- a/MacroTracker/src/components/FirstRunModal.tsx
+++ b/MacroTracker/src/components/FirstRunModal.tsx
@@ -189,7 +189,7 @@ const FirstRunModal: React.FC<FirstRunModalProps> = ({
                                 <Text h4 style={[styles.title, { color: theme.colors.text }]}>
                                     {t('firstRunModal.title')}
                                 </Text>
-                                <Text style={[styles.subtitle, { color: theme.colors.grey2 }]}>
+                                <Text style={[styles.subtitle, { color: theme.colors.secondary }]}>
                                     We've updated our legal terms and safety requirements. Please review and agree to continue.
                                 </Text>
                             </View>

--- a/MacroTracker/src/components/GuestLimitModal.tsx
+++ b/MacroTracker/src/components/GuestLimitModal.tsx
@@ -37,7 +37,7 @@ const GuestLimitModal: React.FC<GuestLimitModalProps> = ({ isVisible, onClose, f
           <Text h4 style={[styles.title, { color: theme.colors.text }]}>
             {t('guestLimit.title')}
           </Text>
-          <Text style={[styles.message, { color: theme.colors.grey2 }]}>
+          <Text style={[styles.message, { color: theme.colors.secondary }]}>
             {t('guestLimit.message', { feature: featureName })}
           </Text>
           

--- a/MacroTracker/src/screens/ForgotPasswordScreen.tsx
+++ b/MacroTracker/src/screens/ForgotPasswordScreen.tsx
@@ -47,7 +47,7 @@ const ForgotPasswordScreen: React.FC = () => {
                 <Text h3 style={[styles.title, { color: theme.colors.text }]}>
                     {t('forgotPasswordScreen.title')}
                 </Text>
-                <Text style={[styles.instructions, { color: theme.colors.grey2 }]}>
+                <Text style={[styles.instructions, { color: theme.colors.secondary }]}>
                     {t('forgotPasswordScreen.instructions')}
                 </Text>
                 <Input


### PR DESCRIPTION
Replaced usage of theme.colors.grey2 with theme.colors.secondary for message and subtitle text in AiPromotionModal, FirstRunModal, GuestLimitModal, and ForgotPasswordScreen to ensure consistent theming.