### PR TITLE
Use friendly ad error messages (hide 'no-fill')

### DIFF
--- a/MacroTracker/src/services/adService.ts
+++ b/MacroTracker/src/services/adService.ts
@@ -103,7 +103,14 @@ export const showRewardedAd = (userId: string): Promise<boolean> => {
             const unsubscribeError = rewardedAd.addAdEventListener(AdEventType.ERROR, (error) => {
                 console.error('Ad failed to load or show:', error);
                 notifyLoading(false); // Stop loading indicator on error
-                const errorMessage = error?.message || t('ads.error.loadFailed');
+                
+                let errorMessage = t('ads.error.loadFailed');
+                if (error?.message && !error.message.includes('no-fill')) {
+                    // Only use the raw error message if it's not a generic no-fill error
+                    // to prevent ugly SDK strings from showing to the user.
+                    errorMessage = error.message;
+                }
+                
                 Alert.alert(t('ads.error.title'), errorMessage);
                 isAdShowing = false;
                 unsubscribeAll();


### PR DESCRIPTION
Update ad error handling to prefer a translated, user-friendly message and only surface the raw SDK error text when it isn't a generic 'no-fill' message. This prevents ugly/noisy SDK strings from being shown to users while retaining detailed errors when relevant.